### PR TITLE
add script for m1; fix old script error (untested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ It implements an [egui](https://github.com/emilk/egui) ui for the [vst gain effe
 
 The plugin logs events to `~/tmp/EGUIBaseviewTest.log`.
 
-## Usage: macOS (Untested)
+## Usage: macOS (Tested on M1; need to test on previous models)
 
-- Run `scripts/macos-build-and-install.sh`
+- Run `sudo zsh scripts/macos-build-and-install.sh`
 - Start your DAW, test the plugin
+
+> For M1 users, run `sudo zsh scripts/macos-build-and-install-m1.sh`
 
 ## Usage: Windows
 

--- a/scripts/macos-build-and-install-m1.sh
+++ b/scripts/macos-build-and-install-m1.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# https://github.com/RustAudio/vst-rs/issues/175
+
+rustup target install x86_64-apple-darwin
+
 set -e
 
 # Settings
@@ -12,8 +16,8 @@ VST_NAME="$NAME.vst"
 MOVE_TO="/Library/Audio/Plug-Ins/VST/$VST_NAME"
 TMP_DIR="tmp"
 
-cargo build --release
-./scripts/osx_vst_bundler.sh "$NAME" ./target/release/libegui_baseview_test_vst2.dylib
+cargo build --target x86_64-apple-darwin --release
+sudo zsh ./scripts/osx_vst_bundler.sh "$NAME" ./target/x86_64-apple-darwin/release/libegui_baseview_test_vst2.dylib
 
 if [ -d "$MOVE_TO" ]; then
     rm -r "$MOVE_TO"


### PR DESCRIPTION
Add script for Apple M1, based on:
https://github.com/RustAudio/vst-rs/issues/175
Fix the target name `libegui_baseview_test_vst2.dylib` error on the old script as well.